### PR TITLE
mini optimization (test)

### DIFF
--- a/cad_source/zengine/core/entities/uzeentmtext.pas
+++ b/cad_source/zengine/core/entities/uzeentmtext.pas
@@ -971,21 +971,16 @@ begin
   //format;
 end;
 function z2dxfmtext(s:String;var ul:boolean):String;
-var i:Integer;
+var count:Integer;
 begin
-     result:=s;
-     repeat
-          i:=pos(#1,result);
-          if i>0 then
-                     begin
-                          if not(ul) then
-                                         result:=copy(result,1,i-1)+'\L'+copy(result,i+1,length(result)-i)
-                                     else
-                                         result:=copy(result,1,i-1)+'\l'+copy(result,i+1,length(result)-i);
-
-                          ul:=not(ul);
-                     end;
-     until i<=0;
+    result:=s;
+    repeat
+        if not(ul) then
+                       result:=StringReplace(result,#1,'\L',[],count)
+                   else
+                       result:=StringReplace(result,#1,'\l',[],count);
+        ul:=not(ul);
+    until count=0;
 end;
 procedure GDBObjMText.SaveToDXF(var outhandle:{Integer}TZctnrVectorBytes;var drawing:TDrawingDef;var IODXFContext:TIODXFContext);
 var


### PR DESCRIPTION
Небольшая оптимизация, вначале сделал один вариант, с экономией одного copy, но потом как оказалось библиотечный StringReplace ещё более быстрый!

Если подтвердишь правильность, то на StringReplace можно много где переделать похоже...

Код для теста:
```
program FPC_Benchmark;

uses SysUtils;

var
  n: LongWord;
  t1, t2: TDateTime;
  s,s1,s2,s3:String;
  b: Boolean;

  function z2dxfmtext(s:String;var ul:boolean):String;
  var i:Integer;
  begin
       result:=s;
       repeat
            i:=pos(#1,result);
            if i>0 then
                       begin
                            if not(ul) then
                                           result:=copy(result,1,i-1)+'\L'+copy(result,i+1,length(result)-i)
                                       else
                                           result:=copy(result,1,i-1)+'\l'+copy(result,i+1,length(result)-i);

                            ul:=not(ul);
                       end;
       until i<=0;
  end;

function z2dxfmtext2(s:String;var ul:boolean):String;
var i:Integer;
    temp_s:String;
begin
     result:=s;
     repeat
          i:=pos(#1,result);
          if i>0 then
                     begin
                          temp_s:=copy(result,i+1,length(result)-i);
                          SetLength(result, i-1);
                          if not(ul) then
                                         result:=result+'\L'+temp_s
                                     else
                                         result:=result+'\l'+temp_s;

                          ul:=not(ul);
                     end;
     until i<=0;
end;

function z2dxfmtext3(s:String;var ul:boolean):String;
var count:Integer;
begin
    result:=s;
    repeat
        if not(ul) then
                       result:=StringReplace(result,#1,'\L',[],count)
                   else
                       result:=StringReplace(result,#1,'\l',[],count);
        ul:=not(ul);
    until count=0;
end;

begin
  s:='string1'#1'string2'#1'string3'#1'string4|stringstring5';
  s:=s+'_';

  b:=false;
  Write('old: ');
  t1:=Now;
  for n:=0 to 1000000 do
  begin
    s1:=z2dxfmtext(s, b);
  end;
  t2:=Now;
  WriteLn('t=', ((t2-t1)*24*60*60):0:3);

  b:=false;
  Write('new 1: ');
  t1:=Now;
  for n:=0 to 1000000 do
  begin
    s2:=z2dxfmtext2(s, b);
  end;
  t2:=Now;
  WriteLn('t=', ((t2-t1)*24*60*60):0:3);

  b:=false;
  Write('new 2: ');
  t1:=Now;
  for n:=0 to 1000000 do
  begin
    s3:=z2dxfmtext3(s, b);
  end;
  t2:=Now;
  WriteLn('t=', ((t2-t1)*24*60*60):0:3);

  Writeln('s1=',s1);
  Writeln('s2=',s2,' ', s1=s2);
  Writeln('s3=',s3,' ', s1=s3);

  ReadLn;
end.
```
