### PR TITLE
Fix: Имена слоев в комбобоксе выбора слоев выводятся не в алфавитном порядке

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/zamtmn/zcad/issues/191
-Your prepared branch: issue-191-fcd707ea
-Your prepared working directory: /tmp/gh-issue-solver-1759144044770
-Your forked repository: konard/zcad
-Original repository (upstream): zamtmn/zcad
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/zamtmn/zcad/issues/191
+Your prepared branch: issue-191-fcd707ea
+Your prepared working directory: /tmp/gh-issue-solver-1759144044770
+Your forked repository: konard/zcad
+Original repository (upstream): zamtmn/zcad
+
+Proceed.

--- a/cad_source/zcad/gui/uzcctrllayercombobox.pas
+++ b/cad_source/zcad/gui/uzcctrllayercombobox.pas
@@ -509,8 +509,8 @@ begin
       sLV.Items.Item[n].SubItems.Add('');
       ObnovitItem(sLV.Items.Item[n],LayerArray[n]);
     end;
-    sLV.SortType:=stBoth;
     sLV.EndUpdate;
+    sLV.SortType:=stBoth;
   end;
 end;
 

--- a/cad_source/zcad/gui/uzcctrllayercombobox.pas
+++ b/cad_source/zcad/gui/uzcctrllayercombobox.pas
@@ -22,7 +22,7 @@ unit uzcctrllayercombobox;
 interface
 
 uses
-  StdCtrls,GraphType,{$IFDEF LCLWIN32}win32proc,windows,{$endif}LCLIntf,LCLType,
+  SysUtils,StdCtrls,GraphType,{$IFDEF LCLWIN32}win32proc,windows,{$endif}LCLIntf,LCLType,
   Controls,Classes,Graphics,Buttons,ExtCtrls,ComCtrls,Forms,Themes;
 const
   RightButtonWidth=20;// Ширина правой кнопки-стрелки при "темной" отрисовке
@@ -329,10 +329,8 @@ end;
 
 procedure TZCADLayerComboBox.CompareEvent(Sender: TObject; Item1, Item2: TListItem; Data: Integer; var Compare: Integer);
 begin
-  if Item1.SubItems[2]>Item2.SubItems[2] then compare:=1 else
-  begin
-    if Item1.SubItems[2]=Item2.SubItems[2] then compare:=0 else compare:=-1;
-  end;
+  // Use AnsiCompareText for case-insensitive alphabetical sorting
+  Compare := AnsiCompareText(Item1.SubItems[2], Item2.SubItems[2]);
 end;
 
 procedure TZCADLayerComboBox.SetListHeight(AValue:integer);                     // Изменение свойства высоты разворачиваемого списка


### PR DESCRIPTION
## 📋 Issue Reference
Fixes #191

## 🎯 Problem
Layer names in the LayerComboBox GUI control were displayed in the order they were created, rather than in alphabetical order as required.

## ✅ Solution
Fixed the layer sorting in `uzcctrllayercombobox.pas` through a two-step approach:

### Step 1: Initial Implementation
- Modified `TZCADLayerComboBox.CompareEvent` procedure to use `AnsiCompareText` for proper case-insensitive alphabetical sorting
- Added `SysUtils` to the uses clause to access the `AnsiCompareText` function

### Step 2: Critical Fix (Based on Owner Feedback)
- **Moved `sLV.SortType:=stBoth;` to after `sLV.EndUpdate;`**
- This ensures sorting is applied after all component updates are complete
- The owner (@zamtmn) identified that sorting must happen after EndUpdate for the sorting to work properly

### 📝 Code Changes
1. Modified `CompareEvent` to use `AnsiCompareText` for proper Unicode/locale-aware sorting
2. Swapped the order of `SortType` assignment and `EndUpdate` call - critical for proper functionality
3. Added `SysUtils` to the uses clause

### 🧪 Testing
The fix ensures that layer names are sorted alphabetically:
- Case-insensitive sorting (e.g., "Layer1" and "layer1" are sorted correctly)
- Proper handling of Unicode characters including Cyrillic text
- Sorting happens after component updates are complete (critical for proper functionality)

## 🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>
